### PR TITLE
lockr AIM: New user ID module

### DIFF
--- a/modules/.submodules.json
+++ b/modules/.submodules.json
@@ -48,7 +48,8 @@
       "gravitoIdSystem",
       "freepassIdSystem",
       "operaadsIdSystem",
-      "mygaruIdSystem"
+      "mygaruIdSystem",
+      "lockrAIMIdSystem"
     ],
     "adpod": [
       "freeWheelAdserverVideo",

--- a/modules/lockrAIMIdSystem.js
+++ b/modules/lockrAIMIdSystem.js
@@ -1,0 +1,57 @@
+import { submodule } from '../src/hook.js';
+import { logInfo, logWarn } from '../src/utils';
+import { lockrAIMCodeVersion, lockrAIMGetIds } from './lockrAIMIdSystem_shared';
+
+/**
+ * @typedef {import('../modules/userId/index.js').Submodule} Submodule
+ * @typedef {import('../modules/userId/index.js').SubmoduleConfig} SubmoduleConfig
+ * @typedef {import('../modules/userId/index.js').ConsentData} ConsentData
+ * @typedef {import('../modules/userId/index.js').lockrAIMId} lockrAIMId
+ */
+
+const MODULE_NAME = 'lockr-aim';
+const MODULE_REVISION = lockrAIMCodeVersion;
+const PREBID_VERSION = '$prebid.version$';
+const LOG_PRE_FIX = 'lockr-AIM: ';
+
+const AIM_PROD_URL = 'https://identity.loc.kr';
+
+function createLogger(logger, prefix) {
+  return function (...strings) {
+    logger(prefix + ' ', ...strings);
+  }
+}
+
+const _logInfo = createLogger(logInfo, LOG_PRE_FIX);
+const _logWarn = createLogger(logWarn, LOG_PRE_FIX);
+
+/** @type {Submodule} */
+export const lockrAIMSubmodule = {
+  name: MODULE_NAME,
+
+  /**
+   * performs action to obtain id and return a value.
+   * @function
+   * @param {SubmoduleConfig} [configparams]
+   * @param {ConsentData|undefined} consentData
+   * @returns {lockrAIMId}
+   */
+  getId(config, consentData) {
+    if (consentData?.gdprApplies === true) {
+      _logWarn('lockrAIM is not intended for use where GDPR applies. The lockrAIM module will not run');
+      return;
+    }
+
+    const mappedConfig = {
+      appID: config?.params?.appID,
+      email: config?.params?.email
+    };
+
+    _logInfo('lockr AIM configurations loaded and mapped.', mappedConfig);
+    lockrAIMGetIds(mappedConfig, _logInfo, _logWarn);
+    _logInfo('lockr AIM results generated');
+  }
+}
+
+// Register submodule for userId
+submodule('userId', lockrAIMSubmodule);

--- a/modules/lockrAIMIdSystem.js
+++ b/modules/lockrAIMIdSystem.js
@@ -1,6 +1,14 @@
+/**
+ * This module adds lockr AIM ID support to the User ID module
+ * The {@link module:modules/userId} module is required.
+ * @module modules/lockrAIMIdSystem
+ * @requires module:modules/userId
+ */
+
 import { submodule } from '../src/hook.js';
-import { logInfo, logWarn } from '../src/utils';
-import { lockrAIMCodeVersion, lockrAIMGetIds } from './lockrAIMIdSystem_shared';
+import { logInfo, logWarn } from '../src/utils.js';
+// eslint-disable-next-line prebid/validate-imports
+import { lockrAIMGetIds } from './lockrAIMIdSystem_shared.js';
 
 /**
  * @typedef {import('../modules/userId/index.js').Submodule} Submodule
@@ -9,9 +17,7 @@ import { lockrAIMCodeVersion, lockrAIMGetIds } from './lockrAIMIdSystem_shared';
  * @typedef {import('../modules/userId/index.js').lockrAIMId} lockrAIMId
  */
 
-const MODULE_NAME = 'lockr-aim';
-const MODULE_REVISION = lockrAIMCodeVersion;
-const PREBID_VERSION = '$prebid.version$';
+const MODULE_NAME = 'lockrAIMId'
 const LOG_PRE_FIX = 'lockr-AIM: ';
 
 const AIM_PROD_URL = 'https://identity.loc.kr';
@@ -27,7 +33,15 @@ const _logWarn = createLogger(logWarn, LOG_PRE_FIX);
 
 /** @type {Submodule} */
 export const lockrAIMSubmodule = {
+  /**
+   * used to link submodule with config
+   * @type {string}
+   */
   name: MODULE_NAME,
+
+  init() {
+    _logInfo('lockrAIM Initialization complete');
+  },
 
   /**
    * performs action to obtain id and return a value.
@@ -44,12 +58,14 @@ export const lockrAIMSubmodule = {
 
     const mappedConfig = {
       appID: config?.params?.appID,
-      email: config?.params?.email
+      email: config?.params?.email,
+      baseUrl: AIM_PROD_URL,
     };
 
     _logInfo('lockr AIM configurations loaded and mapped.', mappedConfig);
-    lockrAIMGetIds(mappedConfig, _logInfo, _logWarn);
+    const result = lockrAIMGetIds(mappedConfig, _logInfo, _logWarn);
     _logInfo('lockr AIM results generated');
+    return result;
   }
 }
 

--- a/modules/lockrAIMIdSystem.md
+++ b/modules/lockrAIMIdSystem.md
@@ -1,0 +1,63 @@
+# lockr AIM
+
+AIM is a unified container for identity and data management. The self-service platform allows you to seamlessly test and integrate alternative identity providers.
+
+With AIM, publishers seamlessly integrate and activate alternative IDs like LiveRamp’s Authenticated Traffic Solution (ATS), Unified ID 2.0 (UID2), ID5 and more. The burden of due diligence and maintenance, coupled with the benefits of server-side calls result in the adoption of multiple alternative IDs, clean rooms like InfoSum and CDPs based on their or advertisers’ specific needs.
+
+## lockr AIM registration
+
+Sign Up for an Identity lockr account: Begin by creating an <a href = "https://sso.loc.kr/console/signup" target = "_blank">Identity lockr account.</a>
+
+Setup your App: Inside Identity lockr, create an app and activate the AIM library.
+
+Compile Prebid: Compile Prebid with the below configurations, and integrate the same.
+
+## lockr AIM Configuration
+
+First, make sure to add the lockr AIM submodule to your Prebid.js package with:
+
+```
+gulp build --modules=lockrAIMIdSystem,userId
+```
+
+The following configuration parameters are available:
+
+```javascript
+pbjs.setConfig({
+    userSync: {
+       userIds: [{
+          name: 'lockrAIMId',
+          params: {
+             email: '<example_email>',
+             appID: '<app_id>'
+          }
+       }]
+    }
+});
+```
+
+| Param | Scope | Type | Description                                                                                                                                                                                                                                                                    | Example |
+| --- | --- | --- | --- | --- |
+| name | Required | String | The name of this module: `"lockrAIMId"`                                                                                                                                                                                                                                             | `"lockrAIMId"` |
+| params | Required | Object | Details for the configuration.                                                                                                                                                                                                                                                        | |
+| params.email | Required | String | This is the email that needs to be passed to get the identity tokens for.                                                                                                                                                                                                             | `test@example.com` |
+| params.aooID | Required | String | This is the app ID acquired from the identity lockr from the generated app                                                                                                                                                                                                            | `test@example.com` |
+
+
+## lockr AIM Example
+
+```javascript
+pbjs.setConfig({
+    userSync: {
+       userIds: [{
+          name: 'lockrAIMId',
+          params: {
+             email: 'test@example.com',
+             appID: 'e84afc5f-4adf-4144-949f-1de5bd151fcc'
+          }
+       }]
+    }
+});
+```
+
+*Note*: The lockr AIM will store the tokens in the respective cookies and local storage as per the different identity providers, and the configurations done by the publisher on the identity lockr.

--- a/modules/lockrAIMIdSystem_shared.js
+++ b/modules/lockrAIMIdSystem_shared.js
@@ -1,0 +1,60 @@
+import { ajax } from '../src/ajax.js';
+
+export const lockrAIMCodeVersion = '1.0';
+
+export class lockrAIMApiClient {
+  constructor(opts, logInfo, logWarn) {
+    this._baseUrl = opts.baseUrl;
+    this._appID = opts.appID;
+    this._email = opts.email;
+    this._logInfo = logInfo;
+    this._logWarn = logWarn;
+  }
+
+  async generateToken() {
+    const url = this._baseUrl + '/publisher/app/v1/identityLockr/generate-tokens';
+    let rejectPromise;
+    const promise = new Promise((resolve, reject) => {
+      rejectPromise = reject;
+    });
+    const requestBody = {
+      appID: this._appID,
+      data: {
+        type: 'email',
+        value: this._email,
+      }
+    }
+    this._logInfo('Sending the token generation request')
+    ajax(url, {
+      success: (responseText) => {
+        try {
+          const response = JSON.parse(responseText);
+          response.data.forEach(cookieitem => {
+            const settings = cookieitem?.settings;
+            if (!settings?.dropLocalStorage) {
+              localStorage.setItem(cookieitem.key_name, cookieitem.advertising_token);
+              localStorage.setItem('identity_lockr_raw_email', data.value);
+              localStorage.setItem(`${cookieitem.key_name}_expiry`, cookieitem.identity_expires);
+              if (!identityLockr.expiryDateKeys.includes(`${cookieitem.key_name}_expiry`)) {
+                identityLockr.expiryDateKeys.push(`${cookieitem.key_name}_expiry`);
+              }
+              localStorage.setItem('lockr_expiry_keys', JSON.stringify(identityLockr.expiryDateKeys));
+            }
+            if (!settings?.dropCookie) {
+              document.cookie = `${cookieitem.key_name}=${cookieitem.advertising_token};`;
+            }
+          });
+          return;
+        } catch (_err) {
+          rejectPromise(responseText);
+        }
+      }
+    }, JSON.stringify(requestBody), { method: 'POST' });
+    return promise;
+  }
+}
+
+export async function lockrAIMGetIds(config, _logInfo, _logWarn) {
+  const tokenGenerator = new lockrAIMApiClient(config, _logInfo, _logWarn);
+  return await tokenGenerator.generateToken();
+}


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
The following PR adds the lockr AIM module as a part of prebid.

AIM is a unified container for identity and data management. The self-service platform allows you to seamlessly test and integrate alternative identity providers.

With AIM, publishers seamlessly integrate and activate alternative IDs like LiveRamp’s Authenticated Traffic Solution (ATS), Unified ID 2.0 (UID2), ID5 and more. The burden of due diligence and maintenance, coupled with the benefits of server-side calls result in the adoption of multiple alternative IDs, clean rooms like InfoSum and CDPs based on their or advertisers’ specific needs.


<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->

